### PR TITLE
Update from Tricentis-qTest/qtest-chart

### DIFF
--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -59,15 +59,15 @@ maintainers:
   - name: liemng
     email: l.nguyen@tricentis.com
 home: https://github.com/Tricentis-qTest/qtest-chart.git
-kubeVersion: ">=1.18.0-0"
+kubeVersion: ">=1.24.0-0"
 icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_landscape_c2d6524c36c94138504f7a18bf179d76/tricentis-qtest.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.5.0
+version: qtest-mgr-1.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2023.5.7-f096636"
+appVersion: "2024.1.op"

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
           {{ .Values.startupProbe | toYaml | indent 10 | trim }}
         {{- end }}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- .Values.ui.resources | default .Values.resources | toYaml | nindent 10 }}
         {{- with .Values.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -341,7 +341,7 @@ spec:
           {{ .Values.startupProbe | toYaml | indent 10 | trim }}
         {{- end }}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- .Values.poller.resources | default .Values.resources | toYaml | nindent 10 }}
         {{- with .Values.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -544,7 +544,7 @@ spec:
           {{ .Values.startupProbe | toYaml | indent 10 | trim }}
         {{- end }}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- .Values.notification.resources | default .Values.resources | toYaml | nindent 10 }}
         {{- with .Values.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}
@@ -747,7 +747,7 @@ spec:
           {{ .Values.startupProbe | toYaml | indent 10 | trim }}
         {{- end }}
         resources:
-          {{- toYaml .Values.resources | nindent 10 }}
+          {{- .Values.api.resources | default .Values.resources | toYaml | nindent 10 }}
         {{- with .Values.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -55,8 +55,8 @@ image:
   repository: tricentisimage/qtest-mgr
   liquibase: tricentisimage/qtest-mgr-liquibase
   pullPolicy: IfNotPresent
-  tag: "2023.5.7-f096636"
-  liquibasetag: "2023.5.7-f096636"
+  tag: "2024.1.op"
+  liquibasetag: "2024.1.op"
   liquibasepullpolicy: IfNotPresent
 imageCredentials:
   enabled: false
@@ -254,6 +254,7 @@ ui:
   ## if single instance then change to postgres
   springProfilesActive: postgres,readOnlyEnable
   useriqEnabled: false
+  resources: {}
 api:
   appName: api
   asyncThreadNumber: 100
@@ -275,6 +276,7 @@ api:
     dbcp:
       maxActive: 400
   springProfilesActive: postgres,disableAllTasksMode,readOnlyEnable,backgroundQueue
+  resources: {}
 poller:
   appName: notification
   asyncThreadNumber: 100
@@ -290,6 +292,7 @@ poller:
   testconductorAppPath: testconductor-app.localhost.xml
   queuePublisherMaxDequeue: 300
   springProfilesActive: postgres,oldTrackingDefect,disableAllTasksMode
+  resources: {}
 notification:
   action:
     task:
@@ -317,6 +320,7 @@ notification:
   springProfilesActive: postgres,backgroundQueue
   schedulerBlobHandleMaxRetryTimes: 5
   queuePublisherMaxDequeue: 300
+  resources: {}
 testconductor:
   environment:
     isOnPremise: true
@@ -333,6 +337,16 @@ testconductor:
       api: api.onpremise
       poller: poller.onpremise
       notification: notification.onpremise
+#### Shared Resources definition for app Mgr pods in case you don't want to to define it on per pod basis
+### You may also define per Mgr pod Resources above
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
 #### Ingress/IngressClass (> K8s 1.24-1.30+) #####
 ingressClass:
   enabled: false
@@ -456,18 +470,6 @@ limitRange:
         cpu: "2"
         memory: 4Gi
       type: Container
-resources: {}
-## We usually recommend not to specify default resources and to leave this as a conscious
-## choice for the user. This also increases chances charts run on environments with little
-## resources, such as Minikube. If you do want to specify resources, uncomment the following
-## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-# limits:
-#   cpu: 100m
-#   memory: 128Mi
-# requests:
-#   cpu: 100m
-#   memory: 128Mi
-
 ## Readiness, liveness and startup probes
 livenessProbe:
   httpGet:


### PR DESCRIPTION
* Update Manager version from 2023.5.7 to 2024.1
* Manager chart now supports option for defining Resources per deployment (ui, api, poller, notifcation) instead of using shared definition