### PR TITLE
SRE-1007 Release new charts

### DIFF
--- a/Charts/qtest-insights-etl/Chart.yaml
+++ b/Charts/qtest-insights-etl/Chart.yaml
@@ -26,7 +26,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights-etl/templates/_helpers.tpl
+++ b/Charts/qtest-insights-etl/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-insights-etl.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-insights-etl
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-insights-etl/templates/deployment.yaml
+++ b/Charts/qtest-insights-etl/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-insights-etl.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -144,4 +145,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-insights-etl/values.yaml
+++ b/Charts/qtest-insights-etl/values.yaml
@@ -30,6 +30,7 @@ serviceAccount:
   name: "qtest-insightsetl-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -132,3 +133,6 @@ limitRange:
   enabled: false
 resourceQuota:
   enabled: false
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-insights/Chart.yaml
+++ b/Charts/qtest-insights/Chart.yaml
@@ -31,7 +31,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.5.0
+version: 1.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights/templates/_helpers.tpl
+++ b/Charts/qtest-insights/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-insights.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-insights
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-insights/templates/deployment.yaml
+++ b/Charts/qtest-insights/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-insights.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -171,3 +172,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-insights/values.yaml
+++ b/Charts/qtest-insights/values.yaml
@@ -27,6 +27,7 @@ serviceAccount:
   name: "qtest-insights-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -228,3 +229,6 @@ limitRange:
   enabled: false
 resourceQuota:
   enabled: false
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -33,4 +33,4 @@ version: 1.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2024.1.op"
+appVersion: "2024.1.op"

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -28,9 +28,9 @@ kubeVersion: ">=1.24.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.3.0
+version: 1.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2024.1.op"
+appVersion: "v2024.1.op"

--- a/Charts/qtest-launch/templates/_helpers.tpl
+++ b/Charts/qtest-launch/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-launch.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-launch
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-launch/templates/deployment.yaml
+++ b/Charts/qtest-launch/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-launch.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -215,3 +216,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end -}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-launch/values.yaml
+++ b/Charts/qtest-launch/values.yaml
@@ -9,7 +9,7 @@ secrets:
 image:
   repository: qasymphony/launch
   pullPolicy: IfNotPresent
-  tag: "2024.1.op"
+  tag: "v2024.1.op"
 imageCredentials:
   enabled: false
   # name: ""
@@ -27,6 +27,7 @@ serviceAccount:
   name: "qtest-launch-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -181,3 +182,6 @@ startupSslProbe:
     port: 3443
   failureThreshold: 4
   periodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -65,7 +65,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.6.0
+version: 1.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/_helpers.tpl
+++ b/Charts/qtest-mgr/templates/_helpers.tpl
@@ -80,3 +80,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-mgr.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - {{ . }}
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -14,12 +14,13 @@
 {{- $notificationProfile = .Values.testconductor.environment.op.notification -}}
 {{- $singleProfile = .Values.testconductor.environment.op.single -}}
 {{- end }}
+{{- $affinityUi := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-mgr.podAntiAffinity" "qtest-mgr" | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mgr-ui-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -67,7 +68,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with $affinityUi }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -222,12 +223,15 @@ spec:
 {{- end }}
 ---
 {{ if not $iSingleInstance }}
+{{- $affinityPoller := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-mgr.podAntiAffinity" "qtest-mgr-poller" | fromYaml) (dict)) -}}
+{{- $affinityNotification := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-mgr.podAntiAffinity" "qtest-mgr-notification" | fromYaml) (dict)) -}}
+{{- $affinityApi := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-mgr.podAntiAffinity" "qtest-mgr-api" | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mgr-poller-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -275,7 +279,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with $affinityPoller }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -430,7 +434,7 @@ kind: Deployment
 metadata:
   name: mgr-notification-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -478,7 +482,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with $affinityNotification }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -633,7 +637,7 @@ kind: Deployment
 metadata:
   name: mgr-api-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.annotations }}
+  {{- with .Values.deployment.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -681,7 +685,7 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with $affinityApi }}
       affinity:
 {{ toYaml . | indent 8 }}
     {{- end }}

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 metadata:
   name: mgr-ui-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.deployment.annotations }}
+  {{- with (default .Values.deployment.annotations .Values.annotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -231,7 +231,7 @@ kind: Deployment
 metadata:
   name: mgr-poller-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.deployment.annotations }}
+  {{- with (default .Values.deployment.annotations .Values.annotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -434,7 +434,7 @@ kind: Deployment
 metadata:
   name: mgr-notification-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.deployment.annotations }}
+  {{- with (default .Values.deployment.annotations .Values.annotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -637,7 +637,7 @@ kind: Deployment
 metadata:
   name: mgr-api-deployment
   namespace: {{ .Values.namespace.name }}
-  {{- with .Values.deployment.annotations }}
+  {{- with (default .Values.deployment.annotations .Values.annotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -48,7 +48,9 @@ liquibase:
     # argocd.argoproj.io/hook: PreSync
     # argocd.argoproj.io/sync-wave: "-5"
     # argocd.argoproj.io/hook-delete-policy: HookSucceeded, BeforeHookCreation
-annotations: {}
+deployment:
+  annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 podLabels: {}
 image:

--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/templates/_helpers.tpl
+++ b/Charts/qtest-parameters/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-parameters.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-parameters
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-parameters/templates/deployment.yaml
+++ b/Charts/qtest-parameters/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-parameters.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -225,3 +226,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-parameters/values.yaml
+++ b/Charts/qtest-parameters/values.yaml
@@ -27,6 +27,7 @@ serviceAccount:
   name: "qtest-parameters-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -183,3 +184,6 @@ startupSslProbe:
     port: 5443
   failureThreshold: 4
   periodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -22,14 +22,12 @@ maintainers:
     email: p.jaladi@ext.tricentis.com
   - name: liemng
     email: l.nguyen@tricentis.com
-  - name: tomasw
-    email: t.wallick@ext.tricentis.com
 home: https://github.com/Tricentis-qTest/qtest-chart.git
 kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/_helpers.tpl
+++ b/Charts/qtest-pulse/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-pulse.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-pulse
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-pulse/templates/deployment.yaml
+++ b/Charts/qtest-pulse/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-pulse.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -243,3 +244,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-pulse/templates/hpa.yaml
+++ b/Charts/qtest-pulse/templates/hpa.yaml
@@ -31,7 +31,6 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
-{{- end }}
 {{- else }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -64,4 +63,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/Charts/qtest-pulse/values.yaml
+++ b/Charts/qtest-pulse/values.yaml
@@ -26,6 +26,7 @@ serviceAccount:
   name: "qtest-pulse-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -78,7 +79,7 @@ qTestPulse:
   # Optional Value to specify a seperate Pulse executor URL.
   qtestPulseExecutorUrl: ""
   swaggerUrl: https://qtest.dev.tricentis.com
-  qTestPulseDeploymentEnv: "saas"
+  qTestPulseDeploymentEnv: "op"
 #### Ingress/IngressClass (> K8s 1.24-1.30+) #####
 ingressClass:
   enabled: false
@@ -186,3 +187,6 @@ startupSslProbe:
     port: 4443
   failureThreshold: 4
   periodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-scenario/Chart.yaml
+++ b/Charts/qtest-scenario/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-scenario/templates/_helpers.tpl
+++ b/Charts/qtest-scenario/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-scenario.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-scenario
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-scenario/templates/deployment.yaml
+++ b/Charts/qtest-scenario/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-scenario.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -230,3 +231,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end -}}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-scenario/values.yaml
+++ b/Charts/qtest-scenario/values.yaml
@@ -27,6 +27,7 @@ serviceAccount:
   name: "qtest-scenario-sa"
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -183,3 +184,6 @@ startupSslProbe:
     port: 6443
   failureThreshold: 4
   periodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/templates/_helpers.tpl
+++ b/Charts/qtest-session/templates/_helpers.tpl
@@ -66,3 +66,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create podAntiAffinity to avoid multiple pods to be scheduled on single node
+*/}}
+{{- define "qtest-session.podAntiAffinity" -}}
+podAntiAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchExpressions:
+      - key: app
+        operator: In
+        values:
+        - qtest-session
+    topologyKey: "kubernetes.io/hostname"
+{{- end }}

--- a/Charts/qtest-session/templates/deployment.yaml
+++ b/Charts/qtest-session/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $existingImageCredentials := .Values.imageCredentials.existingImageCredentials -}}
 {{- $imageCredentials := .Values.imageCredentials.name -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) | merge (.Values.deployment.singlePodPerNode | ternary (include "qtest-session.podAntiAffinity" . | fromYaml) (dict)) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -272,3 +273,15 @@ spec:
 {{- with .Values.extraVolumes }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Charts/qtest-session/values.yaml
+++ b/Charts/qtest-session/values.yaml
@@ -20,6 +20,7 @@ imageCredentials:
   # existingImageCredentials: ""
 deployment:
   annotations: {}
+  singlePodPerNode: false
 podAnnotations: {}
 rollouts:
   enabled: false
@@ -197,3 +198,6 @@ startupSslProbe:
     port: 8443
   failureThreshold: 4
   periodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Adding `affinity`, `nodeSelector` and `tolerations` to all the charts.
Since `annotations` was moved under `deployment` it has to support both while older has precedence.