### PR TITLE
Update from Tricentis-qTest/qtest-chart

### DIFF
--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/deployment.yaml
+++ b/Charts/qtest-pulse/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: qtest-pulse
+      app: {{ include "qtest-pulse.name" . }}
   template:
     metadata:
       annotations:
@@ -28,7 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app: qtest-pulse
+        app: {{ include "qtest-pulse.name" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"

--- a/Charts/qtest-pulse/templates/service.yaml
+++ b/Charts/qtest-pulse/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    app: qtest-pulse
+    app: {{ include "qtest-pulse.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -25,7 +25,7 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
     {{- end }}
   selector:
-    app: qtest-pulse
+    app: {{ include "qtest-pulse.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.type }}
 ---
@@ -40,7 +40,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-    app: qtest-pulse
+    app: {{ include "qtest-pulse.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -57,7 +57,7 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
     {{- end }}
   selector:
-    app: qtest-pulse
+    app: {{ include "qtest-pulse.name" . }}
     release: {{ .Release.Name }}
   type: {{ .Values.service.type }}
 {{- end }}


### PR DESCRIPTION
New version of `pulse` chart with fixed selectors for a deployment