### PR TITLE
Topology update

### DIFF
--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -65,7 +65,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.7.3
+version: 1.7.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/configmap.yaml
+++ b/Charts/qtest-mgr/templates/configmap.yaml
@@ -89,6 +89,21 @@ data:
   vera.auto.testrun.beta.clients: "{{ .Values.qTestManager.vera.auto.testrun.beta.clients }}"
   sslMountPath: "{{ .Values.qTestManager.server.sslMountPath }}"
   isSSLRequired: "{{ .Values.qTestManager.serverAppSSLRequired }}"
+  {{ if .Values.qTestManager.l2c.enabled }}
+  l2c.config.url: "{{ .Values.qTestManager.l2c.config.url }}"
+  l2c.config.pemFile: "{{ .Values.qTestManager.l2c.config.pemfile }}"
+  l2c.config.issuer: "{{ .Values.qTestManager.l2c.config.issuer }}"
+  l2c.config.webhookUrl: "{{ .Values.qTestManager.l2c.config.webhookUrl }}"
+  l2c.config.defaultProductFamily: "{{ .Values.qTestManager.l2c.config.defaultProductFamily }}"
+  l2c.config.supportedProductFamilies: "{{ .Values.qTestManager.l2c.config.supportedProductFamilies }}"
+  l2c.env.productVersion: "{{ .Values.qTestManager.l2c.env.productVersion }}"
+  l2c.env.environment: "{{ .Values.qTestManager.l2c.env.environment }}"
+  l2c.env.productComponent: "{{ .Values.qTestManager.l2c.env.productComponent }}"
+  l2c.jwttoken.envUrl: "{{ .Values.qTestManager.l2c.jwttoken.envUrl }}"
+  l2c.jwttoken.oktaUrl: "{{ .Values.qTestManager.l2c.jwttoken.oktaUrl }}"
+  l2c.jwttoken.envAudience: "{{ .Values.qTestManager.l2c.jwttoken.envAudience }}"
+  l2c.jwttoken.oktaAudience: "{{ .Values.qTestManager.l2c.jwttoken.oktaAudience }}"
+  {{ end }}
   {{ if .Values.testconductor.environment.isOnPremise }} 
   async.max.cpu: "{{ .Values.qTestManager.async.maxCpu }}"
   async.max.database.cpu: "{{ .Values.qTestManager.async.databaseCpu }}"
@@ -100,7 +115,12 @@ data:
   security.csrf.source.trust.pattern: "{{ .Values.qTestManager.security.csrf.source.trust.pattern }}"
   cors.allowed.all: "{{ .Values.qTestManager.cors.allowed.all }}"
   manager.test.configuration: "{{ .Values.qTestManager.featureFlagOpOverrides.managerTestConfiguration.enabled }}"
+  {{ else }}
+  kong.api.url: "{{ .Values.qTestManager.kong.api.url }}"
+  redis.host: "{{ .Values.qTestManager.redis.host }}"
+  redis.port: "{{ .Values.qTestManager.redis.port }}"
   {{ end }}
+
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -146,6 +166,18 @@ data:
   scheduler.blobHandle.maxRetryTimes: "{{ .Values.notification.schedulerBlobHandleMaxRetryTimes }}"
   action.task.executor.poolSize: "{{ .Values.notification.action.task.executor.poolSize }}"
   com.qasymphony.qtest.event.service.ToscaQueueEventProcessingService.MAX_DEQUEUE: "{{ .Values.notification.queuePublisherMaxDequeue }}"
+  queue.manager.implementation: "{{ .Values.notification.queue.manager.implementation }}"
+  queue.manager.sqs.aws.region: "{{ .Values.notification.queue.manager.awsRegion }}"
+  queue.manager.scheduler.enabled: "{{ .Values.notification.queue.manager.scheduler.enabled }}"
+  queue.manager.scheduler.interval: "{{ .Values.notification.queue.manager.scheduler.interval }}"
+  queue.aws.region: "{{ .Values.notification.queue.manager.awsRegion }}"
+  queue.urls: "{{ .Values.notification.queue.manager.taskQueues }}"
+  queue.url.workqueue: "{{ .Values.notification.queue.manager.workQueue }}"
+  queue.url.workqueueDLQ: "{{ .Values.notification.queue.manager.workQueueDLQ }}"
+  queue.receive.waitTimeSeconds: "{{ .Values.notification.queue.manager.receive.waitTimeSeconds }}"
+  queue.receive.visibilityTimeout: "{{ .Values.notification.queue.manager.receive.visibilityTimeout }}"
+  queue.taskpool.receive.waitTimeSeconds: "{{ .Values.notification.queue.manager.taskpool.receive.waitTimeSeconds }}"
+  queue.taskpool.receive.maxMessages: "{{ .Values.notification.queue.manager.taskpool.receive.maxMessages }}"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -171,6 +203,18 @@ data:
   background.event.test_execution_api.threshold: "{{ .Values.api.background.event.testExecutionApiThreshold }}"
   client.dbcp.maxActive: "{{ .Values.api.client.dbcp.maxActive }}"
   spring.profiles.active: "{{ .Values.api.springProfilesActive }}"
+  queue.manager.implementation: "{{ .Values.api.queue.manager.implementation }}"
+  queue.manager.sqs.aws.region: "{{ .Values.api.queue.manager.awsRegion }}"
+  queue.manager.scheduler.enabled: "{{ .Values.api.queue.manager.scheduler.enabled }}"
+  queue.manager.scheduler.interval: "{{ .Values.api.queue.manager.scheduler.interval }}"
+  queue.aws.region: "{{ .Values.api.queue.manager.awsRegion }}"
+  queue.urls: "{{ .Values.api.queue.manager.taskQueues }}"
+  queue.url.workqueue: "{{ .Values.api.queue.manager.workQueue }}"
+  queue.url.workqueueDLQ: "{{ .Values.api.queue.manager.workQueueDLQ }}"
+  queue.receive.waitTimeSeconds: "{{ .Values.api.queue.manager.receive.waitTimeSeconds }}"
+  queue.receive.visibilityTimeout: "{{ .Values.api.queue.manager.receive.visibilityTimeout }}"
+  queue.taskpool.receive.waitTimeSeconds: "{{ .Values.api.queue.manager.taskpool.receive.waitTimeSeconds }}"
+  queue.taskpool.receive.maxMessages: "{{ .Values.api.queue.manager.taskpool.receive.maxMessages }}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/Charts/qtest-mgr/templates/configmap.yaml
+++ b/Charts/qtest-mgr/templates/configmap.yaml
@@ -89,21 +89,6 @@ data:
   vera.auto.testrun.beta.clients: "{{ .Values.qTestManager.vera.auto.testrun.beta.clients }}"
   sslMountPath: "{{ .Values.qTestManager.server.sslMountPath }}"
   isSSLRequired: "{{ .Values.qTestManager.serverAppSSLRequired }}"
-  {{ if .Values.qTestManager.l2c.enabled }}
-  l2c.config.url: "{{ .Values.qTestManager.l2c.config.url }}"
-  l2c.config.pemFile: "{{ .Values.qTestManager.l2c.config.pemfile }}"
-  l2c.config.issuer: "{{ .Values.qTestManager.l2c.config.issuer }}"
-  l2c.config.webhookUrl: "{{ .Values.qTestManager.l2c.config.webhookUrl }}"
-  l2c.config.defaultProductFamily: "{{ .Values.qTestManager.l2c.config.defaultProductFamily }}"
-  l2c.config.supportedProductFamilies: "{{ .Values.qTestManager.l2c.config.supportedProductFamilies }}"
-  l2c.env.productVersion: "{{ .Values.qTestManager.l2c.env.productVersion }}"
-  l2c.env.environment: "{{ .Values.qTestManager.l2c.env.environment }}"
-  l2c.env.productComponent: "{{ .Values.qTestManager.l2c.env.productComponent }}"
-  l2c.jwttoken.envUrl: "{{ .Values.qTestManager.l2c.jwttoken.envUrl }}"
-  l2c.jwttoken.oktaUrl: "{{ .Values.qTestManager.l2c.jwttoken.oktaUrl }}"
-  l2c.jwttoken.envAudience: "{{ .Values.qTestManager.l2c.jwttoken.envAudience }}"
-  l2c.jwttoken.oktaAudience: "{{ .Values.qTestManager.l2c.jwttoken.oktaAudience }}"
-  {{ end }}
   {{ if .Values.testconductor.environment.isOnPremise }} 
   async.max.cpu: "{{ .Values.qTestManager.async.maxCpu }}"
   async.max.database.cpu: "{{ .Values.qTestManager.async.databaseCpu }}"
@@ -115,12 +100,7 @@ data:
   security.csrf.source.trust.pattern: "{{ .Values.qTestManager.security.csrf.source.trust.pattern }}"
   cors.allowed.all: "{{ .Values.qTestManager.cors.allowed.all }}"
   manager.test.configuration: "{{ .Values.qTestManager.featureFlagOpOverrides.managerTestConfiguration.enabled }}"
-  {{ else }}
-  kong.api.url: "{{ .Values.qTestManager.kong.api.url }}"
-  redis.host: "{{ .Values.qTestManager.redis.host }}"
-  redis.port: "{{ .Values.qTestManager.redis.port }}"
   {{ end }}
-
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -166,18 +146,6 @@ data:
   scheduler.blobHandle.maxRetryTimes: "{{ .Values.notification.schedulerBlobHandleMaxRetryTimes }}"
   action.task.executor.poolSize: "{{ .Values.notification.action.task.executor.poolSize }}"
   com.qasymphony.qtest.event.service.ToscaQueueEventProcessingService.MAX_DEQUEUE: "{{ .Values.notification.queuePublisherMaxDequeue }}"
-  queue.manager.implementation: "{{ .Values.notification.queue.manager.implementation }}"
-  queue.manager.sqs.aws.region: "{{ .Values.notification.queue.manager.awsRegion }}"
-  queue.manager.scheduler.enabled: "{{ .Values.notification.queue.manager.scheduler.enabled }}"
-  queue.manager.scheduler.interval: "{{ .Values.notification.queue.manager.scheduler.interval }}"
-  queue.aws.region: "{{ .Values.notification.queue.manager.awsRegion }}"
-  queue.urls: "{{ .Values.notification.queue.manager.taskQueues }}"
-  queue.url.workqueue: "{{ .Values.notification.queue.manager.workQueue }}"
-  queue.url.workqueueDLQ: "{{ .Values.notification.queue.manager.workQueueDLQ }}"
-  queue.receive.waitTimeSeconds: "{{ .Values.notification.queue.manager.receive.waitTimeSeconds }}"
-  queue.receive.visibilityTimeout: "{{ .Values.notification.queue.manager.receive.visibilityTimeout }}"
-  queue.taskpool.receive.waitTimeSeconds: "{{ .Values.notification.queue.manager.taskpool.receive.waitTimeSeconds }}"
-  queue.taskpool.receive.maxMessages: "{{ .Values.notification.queue.manager.taskpool.receive.maxMessages }}"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -203,18 +171,6 @@ data:
   background.event.test_execution_api.threshold: "{{ .Values.api.background.event.testExecutionApiThreshold }}"
   client.dbcp.maxActive: "{{ .Values.api.client.dbcp.maxActive }}"
   spring.profiles.active: "{{ .Values.api.springProfilesActive }}"
-  queue.manager.implementation: "{{ .Values.api.queue.manager.implementation }}"
-  queue.manager.sqs.aws.region: "{{ .Values.api.queue.manager.awsRegion }}"
-  queue.manager.scheduler.enabled: "{{ .Values.api.queue.manager.scheduler.enabled }}"
-  queue.manager.scheduler.interval: "{{ .Values.api.queue.manager.scheduler.interval }}"
-  queue.aws.region: "{{ .Values.api.queue.manager.awsRegion }}"
-  queue.urls: "{{ .Values.api.queue.manager.taskQueues }}"
-  queue.url.workqueue: "{{ .Values.api.queue.manager.workQueue }}"
-  queue.url.workqueueDLQ: "{{ .Values.api.queue.manager.workQueueDLQ }}"
-  queue.receive.waitTimeSeconds: "{{ .Values.api.queue.manager.receive.waitTimeSeconds }}"
-  queue.receive.visibilityTimeout: "{{ .Values.api.queue.manager.receive.visibilityTimeout }}"
-  queue.taskpool.receive.waitTimeSeconds: "{{ .Values.api.queue.manager.taskpool.receive.waitTimeSeconds }}"
-  queue.taskpool.receive.maxMessages: "{{ .Values.api.queue.manager.taskpool.receive.maxMessages }}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end}}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -158,6 +162,11 @@ spec:
         {{ else }}
           value: {{ $uiProfile }}
         {{- end }}
+        - name: AES_SECRET_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.aesSecretKeysName }}
+              key: AESsecretKeys
 {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -170,6 +179,11 @@ spec:
         {{- if .Values.qTestManager.client.jdbc.sslEnable }}
         - name: qtest-manager-secret-root-volume
           mountPath: {{ .Values.qTestManager.client.jdbc.sslMountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if .Values.qTestManager.l2c.enabled }}
+        - name: qtest-manager-secret-l2c-volume
+          mountPath: {{ .Values.qTestManager.l2c.mountPath }}
           readOnly: true
         {{- end }}
         {{- if .Values.qTestManager.serverAppSSLRequired }}
@@ -202,6 +216,11 @@ spec:
       - name: qtest-manager-secret-root-volume
         secret:
           secretName: qtest-db-root-secret
+      {{- end }}
+      {{- if .Values.qTestManager.l2c.enabled }}
+      - name: qtest-manager-secret-l2c-volume
+        secret:
+          secretName: qtest-l2c-secret
       {{- end }}
       {{- if .Values.qTestManager.serverAppSSLRequired }}
       - name: qtest-manager-secret-ssl-volume
@@ -244,11 +263,7 @@ metadata:
     {{ $key }}: {{ $value }}
 {{- end }}
 spec:
-  {{- if .Values.rollouts.enabled }}
-  replicas: 0
-  {{- else }}
   replicas: {{ .Values.autoscaling.minReplicas.poller }}
-  {{- end }}
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -275,6 +290,10 @@ spec:
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end}}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -368,6 +387,11 @@ spec:
 {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+        - name: AES_SECRET_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.aesSecretKeysName }}
+              key: AESsecretKeys
         volumeMounts:
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
@@ -377,6 +401,11 @@ spec:
          {{- if .Values.qTestManager.client.jdbc.sslEnable }}
         - name: qtest-manager-secret-root-volume
           mountPath: {{ .Values.qTestManager.client.jdbc.sslMountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if .Values.qTestManager.l2c.enabled }}
+        - name: qtest-manager-secret-l2c-volume
+          mountPath: {{ .Values.qTestManager.l2c.mountPath }}
           readOnly: true
         {{- end }}
         {{- if .Values.qTestManager.serverAppSSLRequired }}
@@ -409,6 +438,11 @@ spec:
       - name: qtest-manager-secret-root-volume
         secret:
           secretName: qtest-db-root-secret
+      {{- end }}
+      {{- if .Values.qTestManager.l2c.enabled }}
+      - name: qtest-manager-secret-l2c-volume
+        secret:
+          secretName: qtest-l2c-secret
       {{- end }}
       {{- if .Values.qTestManager.serverAppSSLRequired }}
       - name: qtest-manager-secret-ssl-volume
@@ -478,6 +512,10 @@ spec:
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end}}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -571,6 +609,11 @@ spec:
 {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+        - name: AES_SECRET_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.aesSecretKeysName }}
+              key: AESsecretKeys
         volumeMounts:
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
@@ -580,6 +623,11 @@ spec:
         {{- if .Values.qTestManager.client.jdbc.sslEnable }}
         - name: qtest-manager-secret-root-volume
           mountPath: {{ .Values.qTestManager.client.jdbc.sslMountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if .Values.qTestManager.l2c.enabled }}
+        - name: qtest-manager-secret-l2c-volume
+          mountPath: {{ .Values.qTestManager.l2c.mountPath }}
           readOnly: true
         {{- end }}
         {{- if .Values.qTestManager.serverAppSSLRequired }}
@@ -612,6 +660,11 @@ spec:
       - name: qtest-manager-secret-root-volume
         secret:
           secretName: qtest-db-root-secret
+      {{- end }}
+      {{- if .Values.qTestManager.l2c.enabled }}
+      - name: qtest-manager-secret-l2c-volume
+        secret:
+          secretName: qtest-l2c-secret
       {{- end }}
       {{- if .Values.qTestManager.serverAppSSLRequired }}
       - name: qtest-manager-secret-ssl-volume
@@ -681,6 +734,10 @@ spec:
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end}}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -774,6 +831,11 @@ spec:
 {{- with .Values.extraEnv }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+        - name: AES_SECRET_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.aesSecretKeysName }}
+              key: AESsecretKeys
         volumeMounts:
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
@@ -783,6 +845,11 @@ spec:
         {{- if .Values.qTestManager.client.jdbc.sslEnable }}
         - name: qtest-manager-secret-root-volume
           mountPath: {{ .Values.qTestManager.client.jdbc.sslMountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if .Values.qTestManager.l2c.enabled }}
+        - name: qtest-manager-secret-l2c-volume
+          mountPath: {{ .Values.qTestManager.l2c.mountPath }}
           readOnly: true
         {{- end }}
         {{- if .Values.qTestManager.serverAppSSLRequired }}
@@ -815,6 +882,11 @@ spec:
       - name: qtest-manager-secret-root-volume
         secret:
           secretName: qtest-db-root-secret
+      {{- end }}
+      {{- if .Values.qTestManager.l2c.enabled }}
+      - name: qtest-manager-secret-l2c-volume
+        secret:
+          secretName: qtest-l2c-secret
       {{- end }}
       {{- if .Values.qTestManager.serverAppSSLRequired }}
       - name: qtest-manager-secret-ssl-volume

--- a/Charts/qtest-mgr/templates/hpa.yaml
+++ b/Charts/qtest-mgr/templates/hpa.yaml
@@ -1,17 +1,19 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if .Values.rollouts.enabled -}}
+{{- $targetType := ternary "Rollout" "Deployment" .Values.rollouts.enabled -}}
+{{- $targetSuffix := ternary "rollout" "deployment" .Values.rollouts.enabled -}}
+{{- $targetApiVersion := ternary "argoproj.io/v1alpha1" "apps/v1" .Values.rollouts.enabled -}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: mgr-ui-rollout
+  name: mgr-ui-{{ $targetSuffix }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "qtest-mgr.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1
-    kind: Rollout
-    name: mgr-ui-rollout
+    apiVersion: {{ $targetApiVersion }}
+    kind: {{ $targetType }}
+    name: mgr-ui-{{ $targetSuffix }}
   minReplicas: {{ .Values.autoscaling.minReplicas.ui }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas.ui }}
   metrics:
@@ -36,15 +38,15 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: mgr-api-rollout
+  name: mgr-api-{{ $targetSuffix }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "qtest-mgr.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1
-    kind: Rollout
-    name: mgr-api-rollout
+    apiVersion: {{ $targetApiVersion }}
+    kind: {{ $targetType }}
+    name: mgr-api-{{ $targetSuffix }}
   minReplicas: {{ .Values.autoscaling.minReplicas.api }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas.api }}
   metrics:
@@ -68,47 +70,15 @@ spec:
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: mgr-poller-rollout
+  name: mgr-notification-{{ $targetSuffix }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "qtest-mgr.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1
-    kind: Rollout
-    name: mgr-poller-rollout
-  minReplicas: {{ .Values.autoscaling.minReplicas.poller }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas.poller }}
-  metrics:
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: mgr-notification-rollout
-  namespace: {{ .Values.namespace.name }}
-  labels:
-    {{- include "qtest-mgr.labels" . | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: argoproj.io/v1alpha1
-    kind: Rollout
-    name: mgr-notification-rollout
+    apiVersion: {{ $targetApiVersion }}
+    kind: {{ $targetType }}
+    name: mgr-notification-{{ $targetSuffix }}
   minReplicas: {{ .Values.autoscaling.minReplicas.notification }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas.notification }}
   metrics:
@@ -128,73 +98,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+---
 {{- end -}}
-{{- else }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: mgr-ui-deployment
-  namespace: {{ .Values.namespace.name }}
-  labels:
-    {{- include "qtest-mgr.labels" . | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: mgr-ui-deployment
-  minReplicas: {{ .Values.autoscaling.minReplicas.ui }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas.ui }}
-  metrics:
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
----
-{{ if not .Values.testconductor.environment.singleInstance }}
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: mgr-api-deployment
-  namespace: {{ .Values.namespace.name }}
-  labels:
-    {{- include "qtest-mgr.labels" . | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: mgr-api-deployment
-  minReplicas: {{ .Values.autoscaling.minReplicas.api }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas.api }}
-  metrics:
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
----
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -226,38 +131,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: mgr-notification-deployment
-  namespace: {{ .Values.namespace.name }}
-  labels:
-    {{- include "qtest-mgr.labels" . | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: mgr-notification-deployment
-  minReplicas: {{ .Values.autoscaling.minReplicas.notification }}
-  maxReplicas: {{ .Values.autoscaling.maxReplicas.notification }}
-  metrics:
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-{{- end -}}
-{{- end }}
 {{- end }}

--- a/Charts/qtest-mgr/templates/rollout.yaml
+++ b/Charts/qtest-mgr/templates/rollout.yaml
@@ -36,27 +36,6 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
-  name: mgr-poller-rollout
-  namespace: {{ .Values.namespace.name }}
-spec:
-  replicas: {{ .Values.autoscaling.minReplicas.poller }}
-  revisionHistoryLimit: 3
-  workloadRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: mgr-poller-deployment
-  strategy:
-   {{- with .Values.rollouts.strategy -}}
-      {{- toYaml . | nindent 4 }}
-   {{- end }} 
-      steps:
-      {{- with .Values.rollouts.steps -}}
-          {{- toYaml . | nindent 8 }}
-      {{- end }}
----
-apiVersion: argoproj.io/v1alpha1
-kind: Rollout
-metadata:
   name: mgr-notification-rollout
   namespace: {{ .Values.namespace.name }}
 spec:

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -73,7 +73,6 @@ secrets:
   useExistingTls: false
   ## existingConfigs must be qtest-manager-secret
   # existingConfigs: "qtest-manager-secret"
-  aesSecretKeysName: qtest-aes-secret-keys
 serviceAccount:
   create: true
   name:
@@ -243,31 +242,6 @@ qTestManager:
   featureFlagOpOverrides:
     managerTestConfiguration:
       enabled: false
-  l2c:
-    enabled: false
-    mountPath: /mnt/secrets/l2c
-    config:
-      url: https://localhost
-      pemfile: /mnt/secrets/l2c/..data/license.pem
-      issuer: test
-      webhookUrl: https://localhost
-      defaultProductFamily: QTEST
-      supportedProductFamilies: QTEST
-    env:
-      productVersion: 1.0
-      environment: l2c-dev
-      productComponent: unknown
-    jwttoken:
-      envUrl: https://localhost
-      oktaUrl: https://localhost
-      envAudience: tta.admin
-      oktaAudience: tta.admin
-  kong:
-    api:
-      url: http://localhost:8001
-  redis:
-    host: localhost
-    port: 6379
 ui:
   action:
     task:
@@ -305,23 +279,6 @@ api:
       maxActive: 400
   springProfilesActive: postgres,disableAllTasksMode,readOnlyEnable,backgroundQueue
   resources: {}
-  queue:
-    manager:
-      implementation: "sqs"
-      awsRegion: ""
-      scheduler:
-        enabled: false
-        interval: 3000
-      workQueue: ""
-      workQueueDLQ: ""
-      receive:
-        waitTimeSeconds: 10
-        visibilityTimeout: 30
-      taskpool:
-        receive:
-          waitTimeSeconds: 1
-          maxMessages: 10
-      taskQueues: ""
 poller:
   appName: notification
   asyncThreadNumber: 100
@@ -366,23 +323,6 @@ notification:
   schedulerBlobHandleMaxRetryTimes: 5
   queuePublisherMaxDequeue: 300
   resources: {}
-  queue:
-    manager:
-      implementation: "sqs"
-      awsRegion: ""
-      scheduler:
-        enabled: false
-        interval: 3000
-      workQueue: ""
-      workQueueDLQ: ""
-      receive:
-        waitTimeSeconds: 10
-        visibilityTimeout: 30
-      taskpool:
-        receive:
-          waitTimeSeconds: 1
-          maxMessages: 10
-      taskQueues: ""
 testconductor:
   environment:
     isOnPremise: true
@@ -490,7 +430,7 @@ vpaAutoscaling:
     updateMode: "Off"
   resourcePolicy:
     containerPolicies:
-      - containerName: '*'
+      - containerName: "*"
         controlledValues: RequestsAndLimits
 # HPA values
 autoscaling:

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -73,6 +73,7 @@ secrets:
   useExistingTls: false
   ## existingConfigs must be qtest-manager-secret
   # existingConfigs: "qtest-manager-secret"
+  aesSecretKeysName: qtest-aes-secret-keys
 serviceAccount:
   create: true
   name:
@@ -242,6 +243,31 @@ qTestManager:
   featureFlagOpOverrides:
     managerTestConfiguration:
       enabled: false
+  l2c:
+    enabled: false
+    mountPath: /mnt/secrets/l2c
+    config:
+      url: https://localhost
+      pemfile: /mnt/secrets/l2c/..data/license.pem
+      issuer: test
+      webhookUrl: https://localhost
+      defaultProductFamily: QTEST
+      supportedProductFamilies: QTEST
+    env:
+      productVersion: 1.0
+      environment: l2c-dev
+      productComponent: unknown
+    jwttoken:
+      envUrl: https://localhost
+      oktaUrl: https://localhost
+      envAudience: tta.admin
+      oktaAudience: tta.admin
+  kong:
+    api:
+      url: http://localhost:8001
+  redis:
+    host: localhost
+    port: 6379
 ui:
   action:
     task:
@@ -279,6 +305,23 @@ api:
       maxActive: 400
   springProfilesActive: postgres,disableAllTasksMode,readOnlyEnable,backgroundQueue
   resources: {}
+  queue:
+    manager:
+      implementation: "sqs"
+      awsRegion: ""
+      scheduler:
+        enabled: false
+        interval: 3000
+      workQueue: ""
+      workQueueDLQ: ""
+      receive:
+        waitTimeSeconds: 10
+        visibilityTimeout: 30
+      taskpool:
+        receive:
+          waitTimeSeconds: 1
+          maxMessages: 10
+      taskQueues: ""
 poller:
   appName: notification
   asyncThreadNumber: 100
@@ -323,6 +366,23 @@ notification:
   schedulerBlobHandleMaxRetryTimes: 5
   queuePublisherMaxDequeue: 300
   resources: {}
+  queue:
+    manager:
+      implementation: "sqs"
+      awsRegion: ""
+      scheduler:
+        enabled: false
+        interval: 3000
+      workQueue: ""
+      workQueueDLQ: ""
+      receive:
+        waitTimeSeconds: 10
+        visibilityTimeout: 30
+      taskpool:
+        receive:
+          waitTimeSeconds: 1
+          maxMessages: 10
+      taskQueues: ""
 testconductor:
   environment:
     isOnPremise: true
@@ -430,7 +490,7 @@ vpaAutoscaling:
     updateMode: "Off"
   resourcePolicy:
     containerPolicies:
-      - containerName: "*"
+      - containerName: '*'
         controlledValues: RequestsAndLimits
 # HPA values
 autoscaling:
@@ -519,6 +579,7 @@ startupSslProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}
 ### qtest-launch ###################################################
 qtest-launch:
   enabled: false


### PR DESCRIPTION
Enable option for updating `'topologySpreadConstraints'` + The `poller` does not have a service so it does not have any reason to have a Rollout. Removing it.

