### PR TITLE
Add topologySpreadConstraints for satellite apps

### DIFF
--- a/Charts/qtest-insights/Chart.yaml
+++ b/Charts/qtest-insights/Chart.yaml
@@ -31,7 +31,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.6.2
+version: 1.6.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights/templates/deployment.yaml
+++ b/Charts/qtest-insights/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- with .Values.topologySpreadConstraints }}
+        topologySpreadConstraints:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- if .Values.securityContext }}
       securityContext: {{- toYaml .Values.securityContext | nindent 8 }}

--- a/Charts/qtest-insights/values.yaml
+++ b/Charts/qtest-insights/values.yaml
@@ -232,3 +232,4 @@ resourceQuota:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -28,7 +28,7 @@ kubeVersion: ">=1.24.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.4.2
+version: 1.4.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-launch/templates/deployment.yaml
+++ b/Charts/qtest-launch/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+        topologySpreadConstraints:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
     {{ if .Values.imageCredentials.enabled }}
       {{ if .Values.imageCredentials.existingImageCredentials }}
       imagePullSecrets:

--- a/Charts/qtest-launch/values.yaml
+++ b/Charts/qtest-launch/values.yaml
@@ -186,3 +186,4 @@ startupSslProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}

--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/templates/deployment.yaml
+++ b/Charts/qtest-parameters/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+        topologySpreadConstraints:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
     {{ if .Values.imageCredentials.enabled }}
       {{ if .Values.imageCredentials.existingImageCredentials }}
       imagePullSecrets:

--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/deployment.yaml
+++ b/Charts/qtest-pulse/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+    {{ toYaml . | indent 8 }}
+    {{- end }}
     {{ if .Values.imageCredentials.enabled }}
       {{ if .Values.imageCredentials.existingImageCredentials }}
       imagePullSecrets:

--- a/Charts/qtest-pulse/values.yaml
+++ b/Charts/qtest-pulse/values.yaml
@@ -190,3 +190,4 @@ startupSslProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}

--- a/Charts/qtest-scenario/Chart.yaml
+++ b/Charts/qtest-scenario/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-scenario/templates/deployment.yaml
+++ b/Charts/qtest-scenario/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+    {{ toYaml . | indent 8 }}
+    {{- end }}
     {{ if .Values.imageCredentials.enabled }}
       {{ if .Values.imageCredentials.existingImageCredentials }}
       imagePullSecrets:

--- a/Charts/qtest-scenario/values.yaml
+++ b/Charts/qtest-scenario/values.yaml
@@ -188,3 +188,4 @@ startupSslProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}

--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
+version: 1.5.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/templates/deployment.yaml
+++ b/Charts/qtest-session/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+    {{ toYaml . | indent 8 }}
+    {{- end }}
     {{ if .Values.imageCredentials.enabled }}
       {{ if .Values.imageCredentials.existingImageCredentials }}
       imagePullSecrets:

--- a/Charts/qtest-session/values.yaml
+++ b/Charts/qtest-session/values.yaml
@@ -202,3 +202,4 @@ startupSslProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+topologySpreadConstraints: {}


### PR DESCRIPTION
Enable option for updating `'topologySpreadConstraints'` for qtest satellite apps