### PR TITLE
SRE-2307 Fix rollout spec - quotes around empty annotationPrefix

### DIFF
--- a/Charts/qtest-insights-etl/Chart.yaml
+++ b/Charts/qtest-insights-etl/Chart.yaml
@@ -26,7 +26,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.2
+version: 1.5.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights-etl/templates/rollout.yaml
+++ b/Charts/qtest-insights-etl/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-insights/Chart.yaml
+++ b/Charts/qtest-insights/Chart.yaml
@@ -31,7 +31,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.7.1
+version: 1.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights/templates/rollout.yaml
+++ b/Charts/qtest-insights/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -28,7 +28,7 @@ kubeVersion: ">=1.24.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.5.0
+version: 1.5.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-launch/templates/rollout.yaml
+++ b/Charts/qtest-launch/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -65,7 +65,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.9.1
+version: 1.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/rollout.yaml
+++ b/Charts/qtest-mgr/templates/rollout.yaml
@@ -20,7 +20,7 @@ spec:
       stableService: mgr-service
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}
@@ -53,7 +53,7 @@ spec:
       stableService: mgr-service-notification
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}
@@ -85,7 +85,7 @@ spec:
       stableService: mgr-service-api
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/templates/rollout.yaml
+++ b/Charts/qtest-parameters/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -27,7 +27,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.2
+version: 1.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/rollout.yaml
+++ b/Charts/qtest-pulse/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-scenario/Chart.yaml
+++ b/Charts/qtest-scenario/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.3
+version: 1.4.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-scenario/templates/rollout.yaml
+++ b/Charts/qtest-scenario/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}

--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -25,7 +25,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.6.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/templates/rollout.yaml
+++ b/Charts/qtest-session/templates/rollout.yaml
@@ -19,7 +19,7 @@ spec:
       stableService: {{ .Values.service.serviceName }}
       trafficRouting:
         {{ .Values.rollouts.ingressClassName }}:
-          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix }}
+          annotationPrefix: {{ .Values.ingress.canary.annotationPrefix | quote }}
           {{- with .Values.ingress.canary.annotations }}
           additionalIngressAnnotations:
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Followup of Tricentis-qTest/qtest-chart#627

Quotes around strategy.canary.trafficRouting.alb.annotationPrefix. It gave null when empty string (default value) was passed here.