### PR TITLE
Adding secret for mounting extra cert

### DIFF
--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -61,7 +61,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.12.4
+version: 1.12.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -190,6 +190,11 @@ spec:
         {{- end }}
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
+        {{- if .Values.secrets.javaCertsSecretEnabled }}
+        - name: qtest-java-certs
+          mountPath: {{ .Values.qTestManager.extraCerts.mountPath }}
+          readOnly: true
+        {{- end }}
         - name: qtest-manager-secret-storage
           mountPath: {{ .Values.qTestManager.secret.volumeMount }}
           readOnly: true
@@ -229,6 +234,15 @@ spec:
       {{ else }}
           secretName: qtest-manager-secret
       {{- end }}
+      {{- if .Values.secrets.javaCertsSecretEnabled }}
+      - name: qtest-java-certs
+        secret:
+      {{- if .Values.secrets.javaCertsSecretName }}
+          secretName: {{ .Values.secrets.javaCertsSecretName }}
+      {{ else }}
+          secretName: java-certs-secret
+      {{- end }}
+      {{- end}}
       {{- if .Values.qTestManager.client.jdbc.sslEnable }}
       - name: qtest-manager-secret-root-volume
         secret:
@@ -434,6 +448,11 @@ spec:
         {{- end }}
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
+        {{- if .Values.secrets.javaCertsSecretEnabled }}
+        - name: qtest-java-certs
+          mountPath: {{ .Values.qTestManager.extraCerts.mountPath }}
+          readOnly: true
+        {{- end }}
         - name: qtest-manager-secret-storage
           mountPath: {{ .Values.qTestManager.secret.volumeMount }}
           readOnly: true
@@ -678,6 +697,11 @@ spec:
         {{- end }}
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
+        {{- if .Values.secrets.javaCertsSecretEnabled }}
+        - name: qtest-java-certs
+          mountPath: {{ .Values.qTestManager.extraCerts.mountPath }}
+          readOnly: true
+        {{- end }}
         - name: qtest-manager-secret-storage
           mountPath: {{ .Values.qTestManager.secret.volumeMount }}
           readOnly: true
@@ -922,6 +946,11 @@ spec:
         {{- end }}
         - name: qtest-data
           mountPath: {{ .Values.qTestManager.data.volumeMount }}
+        {{- if .Values.secrets.javaCertsSecretEnabled }}
+        - name: qtest-java-certs
+          mountPath: {{ .Values.qTestManager.extraCerts.mountPath }}
+          readOnly: true
+        {{- end }}
         - name: qtest-manager-secret-storage
           mountPath: {{ .Values.qTestManager.secret.volumeMount }}
           readOnly: true

--- a/Charts/qtest-mgr/templates/secret.yaml
+++ b/Charts/qtest-mgr/templates/secret.yaml
@@ -13,6 +13,18 @@ metadata:
     "helm.sh/hook-weight": "-5"
 type: Opaque
 {{- end }}
+{{- if and .Values.secrets.javaCertsSecretEnabled (not .Values.secrets.javaCertsSecretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: java-certs-secret
+  namespace: {{ .Values.namespace.name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+type: Opaque
+{{- end }}
 {{- if and .Values.imageCredentials.enabled (not .Values.imageCredentials.existingImageCredentials) }}
 ---
 apiVersion: v1

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -72,6 +72,9 @@ secrets:
   ## existingConfigs must be qtest-manager-secret
   # existingConfigs: "qtest-manager-secret"
   aesSecretKeysName: qtest-aes-secret-keys
+  # Optional: name of a secret containing .pem certificates to mount in /certs/java
+  javaCertsSecretEnabled: false
+  javaCertsSecretName: java-certs-secret
   oauthAppsSecretName: qtest-manager-secret
   oauthAppEnv:
     - name: OAUTH_APP_SP_SECRET
@@ -269,6 +272,8 @@ qTestManager:
       testrun:
         beta:
           clients: "null"
+  extraCerts:
+    mountPath: /certs/java
   secret:
     volumeMount: /mnt/secrets/storage
     appVolumeMount: /mnt/secrets/storage/..data


### PR DESCRIPTION
Adding support for mounting an external secret containing certificates to be added to qTest Manager's trusted cacert store.