### PR TITLE
OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED removal

### DIFF
--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -61,7 +61,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.13.7
+version: 1.13.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/deployment.yaml
+++ b/Charts/qtest-mgr/templates/deployment.yaml
@@ -186,8 +186,6 @@ spec:
               key: {{ .key }}
         {{- end }}
         {{- end }}
-        - name: OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED
-          value: {{ .Values.qTestManager.nats.otelInstrumentationOpenTelemetryApiEnabled | quote }}
         {{- end }}
         {{- if .Values.secrets.taisAuthSecretEnabled }}
         {{- with .Values.secrets.taisAuthEnv }}
@@ -471,8 +469,6 @@ spec:
               key: {{ .key }}
         {{- end }}
         {{- end }}
-        - name: OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED
-          value: {{ .Values.qTestManager.nats.otelInstrumentationOpenTelemetryApiEnabled | quote }}
         {{- end }}
         {{- if .Values.secrets.taisAuthSecretEnabled }}
         {{- with .Values.secrets.taisAuthEnv }}
@@ -744,8 +740,6 @@ spec:
               key: {{ .key }}
         {{- end }}
         {{- end }}
-        - name: OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED
-          value: {{ .Values.qTestManager.nats.otelInstrumentationOpenTelemetryApiEnabled | quote }}
         {{- end }}
         {{- if .Values.secrets.taisAuthSecretEnabled }}
         {{- with .Values.secrets.taisAuthEnv }}
@@ -1017,8 +1011,6 @@ spec:
               key: {{ .key }}
         {{- end }}
         {{- end }}
-        - name: OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED
-          value: {{ .Values.qTestManager.nats.otelInstrumentationOpenTelemetryApiEnabled | quote }}
         {{- end }}
         {{- if .Values.secrets.taisAuthSecretEnabled }}
         {{- with .Values.secrets.taisAuthEnv }}

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -164,7 +164,6 @@ qTestManager:
     region: "us-east-1"
     password: ""
     metricsEnabled: false
-    otelInstrumentationOpenTelemetryApiEnabled: false
   client:
     jdbc:
       postgresUrl: "jdbc:postgresql://postgres.local:5432/qtest"


### PR DESCRIPTION
Remove OTEL_INSTRUMENTATION_OPENTELEMETRY_API_ENABLED variable from manager charts as it should be passed as extra env instead