### PR TITLE
Adding Launchdarkly SDK key support, multiple worker threads for Parameters

### DIFF
--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.5
+version: 1.6.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/templates/configmap.yaml
+++ b/Charts/qtest-parameters/templates/configmap.yaml
@@ -31,3 +31,4 @@ data:
   {{-   $nodeOptions = print $nodeOptions " --tls-cipher-list='" (join ":" .Values.qTestParameters.qTestParametersSSLCipherSuites) "'" -}}
   {{- end }}
   qTestParametersNodeOptions: "{{ $nodeOptions }}"
+  qTestParametersWorkerThreads: "{{ .Values.qTestParameters.qTestParametersWorkerThreads }}"

--- a/Charts/qtest-parameters/templates/deployment.yaml
+++ b/Charts/qtest-parameters/templates/deployment.yaml
@@ -169,6 +169,12 @@ spec:
                 configMapKeyRef:
                   name: qtest-parameters-configmap
                   key: qTestParametersDeploymentEnv
+            - name: LAUNCHDARKLY_SDKKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.name }}
+                  key: launchdarkly-sdkKey
+                  optional: true
             - name: SSL_ENABLED
               valueFrom:
                 configMapKeyRef:
@@ -191,6 +197,13 @@ spec:
                 configMapKeyRef:
                   name: qtest-parameters-configmap
                   key: qTestParametersNodeOptions
+            {{- if .Values.qTestParameters.qTestParametersWorkerThreads }}
+            - name: WORKER_THREADS
+              valueFrom:
+                configMapKeyRef:
+                  name: qtest-parameters-configmap
+                  key: qTestParametersWorkerThreads
+            {{- end }}
 {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/Charts/qtest-parameters/values.yaml
+++ b/Charts/qtest-parameters/values.yaml
@@ -81,6 +81,7 @@ qTestParameters:
   qTestParametersCorsOrigin: "tricentis.com"
   qTestParametersDeploymentEnv: "saas"
   qTestParametersNodeOptions: ""
+  qTestParametersWorkerThreads: ""
 #### Ingress/IngressClass (> K8s 1.24-1.30+) #####
 ingressClass:
   enabled: false


### PR DESCRIPTION
Adding Launchdarkly SDK key (feature flag) support for Parameters. Support multiple worker threads for parameters.