### PR TITLE
QTEST-38488: Add search.admin_routes_permitted_clients to qtest-mgr chart

### DIFF
--- a/Charts/qtest-mgr/templates/configmap.yaml
+++ b/Charts/qtest-mgr/templates/configmap.yaml
@@ -42,7 +42,6 @@ data:
   client.jdbc.postgres.readonly.username: "{{ .Values.qTestManager.client.jdbc.postgresReadOnlyUserName }}"
   attachment.folder.path: "{{ .Values.qTestManager.attachmentFolderPath }}"
   license.folder.path: "{{ .Values.qTestManager.licenseFolderPath }}"
-  elasticsearch.permitted_clients: "{{ .Values.qTestManager.elasticSearch.permittedClients }}"
   search.admin_routes_permitted_clients: "{{ .Values.qTestManager.search.adminRoutesPermittedClients }}"
   blobStorage.region: "{{ .Values.qTestManager.blobStorage.region }}"
   blobStorage.sharedBucket: "{{ .Values.qTestManager.blobStorage.sharedBucket }}"

--- a/Charts/qtest-mgr/templates/configmap.yaml
+++ b/Charts/qtest-mgr/templates/configmap.yaml
@@ -43,6 +43,7 @@ data:
   attachment.folder.path: "{{ .Values.qTestManager.attachmentFolderPath }}"
   license.folder.path: "{{ .Values.qTestManager.licenseFolderPath }}"
   elasticsearch.permitted_clients: "{{ .Values.qTestManager.elasticSearch.permittedClients }}"
+  search.admin_routes_permitted_clients: "{{ .Values.qTestManager.search.adminRoutesPermittedClients }}"
   blobStorage.region: "{{ .Values.qTestManager.blobStorage.region }}"
   blobStorage.sharedBucket: "{{ .Values.qTestManager.blobStorage.sharedBucket }}"
   s3.folder: "{{ .Values.qTestManager.s3.folder }}"

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -193,6 +193,8 @@ qTestManager:
       domains: ""
   elasticSearch:
     permittedClients: ""
+  search:
+    adminRoutesPermittedClients: ""
   attachmentFolderPath: /mnt/data/qtest/attachments
   licenseFolderPath: /mnt/data/qtest
   blobStorage:

--- a/Charts/qtest-mgr/values.yaml
+++ b/Charts/qtest-mgr/values.yaml
@@ -191,8 +191,6 @@ qTestManager:
     allowed:
       all: true
       domains: ""
-  elasticSearch:
-    permittedClients: ""
   search:
     adminRoutesPermittedClients: ""
   attachmentFolderPath: /mnt/data/qtest/attachments


### PR DESCRIPTION
## Description

The test-conductor app (PR [#3632](https://github.com/Tricentis-qTest/test-conductor/pull/3632)) renamed `elasticsearch.permitted_clients` → `search.admin_routes_permitted_clients`. A backward-compat fallback reads the old key if the new one is absent, but deployments should migrate to the new key explicitly.

This PR adds the new Helm value and configmap entry so production deployments can configure it via `qTestManager.search.adminRoutesPermittedClients`.

## Changes

- `Charts/qtest-mgr/values.yaml` — adds `qTestManager.search.adminRoutesPermittedClients: ""`
- `Charts/qtest-mgr/templates/configmap.yaml` — adds `search.admin_routes_permitted_clients` entry

The old `elasticsearch.permitted_clients` / `elasticSearch.permittedClients` keys are left untouched for backward compatibility.

Jira link: [QTEST-38488](https://tricentis.atlassian.net/browse/QTEST-38488)