### PR TITLE
Pulse truncate chart label value to satisfy Kubernetes 63-byte limit

### DIFF
--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.6
+version: 1.7.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/deployment.yaml
+++ b/Charts/qtest-pulse/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       labels:
         app: {{ include "qtest-pulse.name" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ include "qtest-pulse.chart" . }}
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:

--- a/Charts/qtest-pulse/templates/pvc.yaml
+++ b/Charts/qtest-pulse/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.namespace.name }}
   labels:
     app: qtest-pulse
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-pulse.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{ if .Values.persistence.annotations}}

--- a/Charts/qtest-pulse/templates/service.yaml
+++ b/Charts/qtest-pulse/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ include "qtest-pulse.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-pulse.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -46,7 +46,7 @@ metadata:
   {{- end }}
   labels:
     app: {{ include "qtest-pulse.name" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-pulse.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/Charts/qtest-pulse/values.yaml
+++ b/Charts/qtest-pulse/values.yaml
@@ -27,10 +27,8 @@ serviceAccount:
 deployment:
   annotations: {}
   singlePodPerNode: false
-
 lifecycle: {}
 podAnnotations: {}
-
 rollouts:
   enabled: false
   ingressClassName: alb


### PR DESCRIPTION
Pulse truncate chart label value to satisfy Kubernetes 63-byte limit