### PR TITLE
Session truncate chart label value to satisfy Kubernetes 63-byte limit 

### DIFF
--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.8
+version: 1.9.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/templates/deployment.yaml
+++ b/Charts/qtest-session/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       labels:
         app: qtest-session
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        chart: {{ include "qtest-session.chart" . }}
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:

--- a/Charts/qtest-session/templates/pvc.yaml
+++ b/Charts/qtest-session/templates/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.namespace.name }}
   labels:
     app: test-conductor
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-session.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 {{ if .Values.persistence.annotations}}

--- a/Charts/qtest-session/templates/service.yaml
+++ b/Charts/qtest-session/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- end }}
   labels:
     app: qtest-session
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-session.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
@@ -42,7 +42,7 @@ metadata:
   {{- end }}
   labels:
     app: qtest-session
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ include "qtest-session.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:

--- a/Charts/qtest-session/values.yaml
+++ b/Charts/qtest-session/values.yaml
@@ -23,11 +23,8 @@ imageCredentials:
 deployment:
   annotations: {}
   singlePodPerNode: false
-
 lifecycle: {}
-
 podAnnotations: {}
-
 rollouts:
   enabled: false
   ingressClassName: alb


### PR DESCRIPTION
Session truncate chart label value to satisfy Kubernetes 63-byte limit 