### PR TITLE
Enhance Vertical Pod Autoscaler (VPA) configuration

### DIFF
--- a/Charts/qtest-insights-etl/Chart.yaml
+++ b/Charts/qtest-insights-etl/Chart.yaml
@@ -22,7 +22,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.6.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights-etl/templates/vpa.yaml
+++ b/Charts/qtest-insights-etl/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,12 +11,33 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "qtest-insights-etl.fullname" . }}
+    name: qtest-insights-etl
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-insights-etl.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-insights-etl.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: qtest-insights-etl-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-insights/Chart.yaml
+++ b/Charts/qtest-insights/Chart.yaml
@@ -25,7 +25,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.8.14
+version: 1.8.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-insights/templates/vpa.yaml
+++ b/Charts/qtest-insights/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,12 +11,33 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "qtest-insights.fullname" . }}
+    name: qtest-insights
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-insights.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-insights.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: qtest-insights-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -24,7 +24,7 @@ kubeVersion: ">=1.24.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.6.8
+version: 1.6.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-launch/Chart.yaml
+++ b/Charts/qtest-launch/Chart.yaml
@@ -24,7 +24,7 @@ kubeVersion: ">=1.24.0-0"
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.6.9
+version: 1.6.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-launch/templates/vpa.yaml
+++ b/Charts/qtest-launch/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,12 +11,33 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "qtest-launch.fullname" . }}
+    name: qtest-launch
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-launch.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-launch.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: qtest-launch-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-mgr/Chart.yaml
+++ b/Charts/qtest-mgr/Chart.yaml
@@ -61,7 +61,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.13.12
+version: 1.13.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-mgr/templates/vpa.yaml
+++ b/Charts/qtest-mgr/templates/vpa.yaml
@@ -31,7 +31,7 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: mgr-deployment-api
+    name: mgr-api-deployment
   updatePolicy:
     updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
@@ -51,7 +51,7 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: mgr-deployment-poller
+    name: mgr-poller-deployment
   updatePolicy:
     updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
@@ -71,7 +71,7 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: mgr-deployment-notification
+    name: mgr-notification-deployment
   updatePolicy:
     updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
@@ -124,15 +124,15 @@ spec:
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: mgr-poller-rollout
+  name: mgr-poller-deployment
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "qtest-mgr.labels" . | nindent 4 }}
 spec:
   targetRef: 
-    apiVersion: "argoproj.io/v1alpha1"
-    kind: Rollout
-    name: mgr-poller-rollout
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: mgr-poller-deployment
   updatePolicy:
     updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:

--- a/Charts/qtest-mgr/templates/vpa.yaml
+++ b/Charts/qtest-mgr/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- $iSingleInstance := .Values.testconductor.environment.singleInstance -}}
 {{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -19,6 +20,7 @@ spec:
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- if not $iSingleInstance }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -80,6 +82,7 @@ spec:
     {{- end }}
       controlledResources: ["cpu", "memory"]
 {{- end }}
+{{- end }}
 {{- if .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -100,6 +103,7 @@ spec:
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- if not $iSingleInstance }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -160,5 +164,6 @@ spec:
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}
 {{- end }}

--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.9
+version: 1.6.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/Chart.yaml
+++ b/Charts/qtest-parameters/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.8
+version: 1.6.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-parameters/templates/vpa.yaml
+++ b/Charts/qtest-parameters/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -12,10 +13,31 @@ spec:
     kind: Deployment
     name: {{ include "qtest-parameters.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-parameters.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-parameters.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: {{ include "qtest-parameters.fullname" . }}-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.7
+version: 1.7.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.6
+version: 1.7.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/templates/vpa.yaml
+++ b/Charts/qtest-pulse/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -12,10 +13,31 @@ spec:
     kind: Deployment
     name: {{ include "qtest-pulse.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-pulse.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-pulse.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: {{ include "qtest-pulse.fullname" . }}-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-scenario/Chart.yaml
+++ b/Charts/qtest-scenario/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.6
+version: 1.7.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-scenario/Chart.yaml
+++ b/Charts/qtest-scenario/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://images.g2crowd.com/uploads/product/image/social_landscape/social_l
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.5
+version: 1.7.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-scenario/templates/vpa.yaml
+++ b/Charts/qtest-scenario/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,12 +11,33 @@ spec:
   targetRef: 
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ include "qtest-scenario.fullname" . }}
+    name: qtest-scenario
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-scenario.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-scenario.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: qtest-scenario-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}

--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.8
+version: 1.9.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/Chart.yaml
+++ b/Charts/qtest-session/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.9
+version: 1.9.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-session/templates/vpa.yaml
+++ b/Charts/qtest-session/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.vpaAutoscaling.enabled }}
+{{- if not .Values.rollouts.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -12,10 +13,31 @@ spec:
     kind: Deployment
     name: {{ include "qtest-session.fullname" . }}
   updatePolicy:
-    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode }}
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
   resourcePolicy:
     {{- with .Values.vpaAutoscaling.resourcePolicy -}}
         {{- toYaml . | nindent 4 }}
     {{- end }}
       controlledResources: ["cpu", "memory"]
+{{- else }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "qtest-session.fullname" . }}-rollout
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "qtest-session.labels" . | nindent 4 }}
+spec:
+  targetRef: 
+    apiVersion: "argoproj.io/v1alpha1"
+    kind: Rollout
+    name: {{ include "qtest-session.fullname" . }}-rollout
+  updatePolicy:
+    updateMode: {{ .Values.vpaAutoscaling.updatePolicy.updateMode | squote }}
+  resourcePolicy:
+    {{- with .Values.vpaAutoscaling.resourcePolicy -}}
+        {{- toYaml . | nindent 4 }}
+    {{- end }}
+      controlledResources: ["cpu", "memory"]
+{{- end }}
 {{- end }}


### PR DESCRIPTION
- add VPA support for Argo Rollouts across all qTest subcharts: when `rollouts.enabled=true`, VPA targets the Rollout; otherwise it targets the Deployment
- fix `qtest-mgr` VPA targetRef names to match actual workload names
- keep poller on Deployment in rollout mode (no `mgr-poller-rollout` exists)
- add `singleInstance` guard to `qtest-mgr` VPA so only the UI VPA is created in default on-premise deployments
- bump chart versions for all affected charts