### PR TITLE
Adjust qtest-pulse probes

### DIFF
--- a/Charts/qtest-pulse/Chart.yaml
+++ b/Charts/qtest-pulse/Chart.yaml
@@ -23,7 +23,7 @@ kubeVersion: ">=1.24.0-0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.8
+version: 1.7.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/Charts/qtest-pulse/values.yaml
+++ b/Charts/qtest-pulse/values.yaml
@@ -169,36 +169,46 @@ livenessProbe:
     path: /
     port: 4080
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 livenessSslProbe:
   httpGet:
     path: /
     scheme: HTTPS
     port: 4443
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 readinessProbe:
   httpGet:
     path: /
     port: 4080
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 readinessSslProbe:
   httpGet:
     path: /
     scheme: HTTPS
     port: 4443
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 startupProbe:
   httpGet:
     path: /
     port: 4080
-  failureThreshold: 4
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 startupSslProbe:
   httpGet:
     path: /
     scheme: HTTPS
     port: 4443
-  failureThreshold: 4
   periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 10
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Adjust `qtest-pulse` Chart probes:

- `timeoutSeconds: 5`, `failureThreshold: 10` on liveness/readiness/startup probes (and their SSL variants), `periodSeconds` stays `30`
- Bump Chart version `1.7.8` → `1.7.9`